### PR TITLE
V0.3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
 compiler:
   - clang
 install:
@@ -13,9 +15,3 @@ script:
   - "nosetests --with-coverage --cover-package=shellinford"
 after_success:
   - coveralls
-notifications:
-  email:
-    recipients:
-      - yukino0131@me.com
-    on_success: always
-    on_failure: always

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,16 @@
 CHANGES
 =======
 
+0.3.5 (2018-09-05)
+------------------
+
+- `FMIndex.build()` and `FMIndex.pushback()` ignore empty string
+- `FMIndex` supports "in" operator. (e.g., 'a' in fm)
+
 0.3.4 (2016-10-28)
 ------------------
 
-- FMIndex.search() returns list
+- `FMIndex.search()` returns list
 
 0.3 (2014-11-24)
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -115,8 +115,15 @@ Write FM-index binary to a file
 - write(path)
 
 
+Check Whether FM-Index contains string
+---------------------------------------
+
+::
+
+ >>> 'baritsu' in fm
+
+
 License
 =========
 - Wrapper code is licensed under the New BSD License.
 - Bundled `shellinford`_ C++ library (c) 2012 echizen_tm is licensed under the New BSD License.
-

--- a/shellinford/__init__.py
+++ b/shellinford/__init__.py
@@ -1,7 +1,7 @@
 from . import shellinford
 
-VERSION = (0, 3, 4)
-__version__ = '0.3.4'
+VERSION = (0, 3, 5)
+__version__ = '0.3.5'
 __all__ = ['FMIndex', 'bit_vector', 'bwt']
 
 FMIndex = shellinford.FMIndex

--- a/shellinford/shellinford.py
+++ b/shellinford/shellinford.py
@@ -440,7 +440,7 @@ class FMIndex(object):
                                          key=lambda x: x[0]):
                     self.fm.push_back(doc)
             else:
-                for doc in docs:
+                for doc in filter(bool, docs):
                     self.fm.push_back(doc)
         self.fm.build()
         if filename:
@@ -489,7 +489,8 @@ class FMIndex(object):
         Params:
             <str> doc
         """
-        self.fm.push_back(doc)
+        if doc:
+            self.fm.push_back(doc)
 
     @property
     def size(self):

--- a/shellinford/shellinford.py
+++ b/shellinford/shellinford.py
@@ -492,6 +492,15 @@ class FMIndex(object):
         if doc:
             self.fm.push_back(doc)
 
+    def __contains__(self, query):
+        """Whether string is in FM-index
+        Params:
+            <str> query
+        Return:
+            <bool>
+        """
+        return bool(self.search(query))
+
     @property
     def size(self):
         return self.fm.size()

--- a/test_shellinford.py
+++ b/test_shellinford.py
@@ -113,6 +113,12 @@ class Test_FMIndex(object):
         finally:
             os.remove(filename)
 
+    def test__in__(self):
+        fm = shellinford.FMIndex()
+        fm.build(['a', 'b'])
+        assert_true('a' in fm)
+        assert_true('c' not in fm)
+
 
 class test_bit_vector(object):
 


### PR DESCRIPTION
- `FMIndex.build()` and `FMIndex.pushback()` ignore empty string
- `FMIndex` supports "in" operator. (e.g., 'a' in fm)
- Support Python 3.5 and 3.6